### PR TITLE
adds StreamsDB tests

### DIFF
--- a/EventFlow.sln
+++ b/EventFlow.sln
@@ -101,6 +101,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB", "Source
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB.Tests", "Source\EventFlow.MongoDB.Tests\EventFlow.MongoDB.Tests.csproj", "{2D837E47-E92B-422E-AC29-AB5607E9E6D1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StreamsDb", "StreamsDb", "{5031948C-F60C-477A-BEDE-ABEC84A38BCE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.EventStores.StreamsDb", "Source\EventFlow.EventStores.StreamsDb\EventFlow.EventStores.StreamsDb.csproj", "{68118439-8371-4AB4-B4B2-13FFFF430390}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +247,10 @@ Global
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68118439-8371-4AB4-B4B2-13FFFF430390}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68118439-8371-4AB4-B4B2-13FFFF430390}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68118439-8371-4AB4-B4B2-13FFFF430390}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68118439-8371-4AB4-B4B2-13FFFF430390}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -282,6 +290,7 @@ Global
 		{5B2706DA-B66C-4CD9-8441-8C9BDACB8348} = {92F3C263-8C0C-4D12-B41A-452E48D2E5E8}
 		{C34BFD0C-E7CD-4DEE-A1F4-8FBE9DE0B239} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
+		{68118439-8371-4AB4-B4B2-13FFFF430390} = {5031948C-F60C-477A-BEDE-ABEC84A38BCE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17607E2C-4E8E-45A2-85BD-0A5808E1C0F3}

--- a/EventFlow.sln
+++ b/EventFlow.sln
@@ -105,6 +105,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StreamsDb", "StreamsDb", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.EventStores.StreamsDb", "Source\EventFlow.EventStores.StreamsDb\EventFlow.EventStores.StreamsDb.csproj", "{68118439-8371-4AB4-B4B2-13FFFF430390}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.EventStores.StreamsDB.Tests", "Source\EventFlow.EventStores.StreamsDb.Tests\EventFlow.EventStores.StreamsDB.Tests.csproj", "{B563415A-D864-490A-B21E-0B24363BA592}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -251,6 +253,10 @@ Global
 		{68118439-8371-4AB4-B4B2-13FFFF430390}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68118439-8371-4AB4-B4B2-13FFFF430390}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68118439-8371-4AB4-B4B2-13FFFF430390}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B563415A-D864-490A-B21E-0B24363BA592}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B563415A-D864-490A-B21E-0B24363BA592}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B563415A-D864-490A-B21E-0B24363BA592}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B563415A-D864-490A-B21E-0B24363BA592}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -291,6 +297,7 @@ Global
 		{C34BFD0C-E7CD-4DEE-A1F4-8FBE9DE0B239} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{68118439-8371-4AB4-B4B2-13FFFF430390} = {5031948C-F60C-477A-BEDE-ABEC84A38BCE}
+		{B563415A-D864-490A-B21E-0B24363BA592} = {5031948C-F60C-477A-BEDE-ABEC84A38BCE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17607E2C-4E8E-45A2-85BD-0A5808E1C0F3}

--- a/Source/EventFlow.EventStores.StreamsDb.Tests/.vscode/launch.json
+++ b/Source/EventFlow.EventStores.StreamsDb.Tests/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.0/EventFlow.EventStores.StreamsDB.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/Source/EventFlow.EventStores.StreamsDb.Tests/.vscode/tasks.json
+++ b/Source/EventFlow.EventStores.StreamsDb.Tests/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/EventFlow.EventStores.StreamsDB.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/EventFlow.EventStores.StreamsDB.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/EventFlow.EventStores.StreamsDB.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Source/EventFlow.EventStores.StreamsDb.Tests/EventFlow.EventStores.StreamsDB.Tests.csproj
+++ b/Source/EventFlow.EventStores.StreamsDb.Tests/EventFlow.EventStores.StreamsDB.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Common.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EventFlow.EventStores.StreamsDb\EventFlow.EventStores.StreamsDb.csproj" />
+    <ProjectReference Include="..\EventFlow.EventStores.EventStore\EventFlow.EventStores.EventStore.csproj" />
+    <ProjectReference Include="..\EventFlow.TestHelpers\EventFlow.TestHelpers.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Source/EventFlow.EventStores.StreamsDb.Tests/IntegrationTests/StreamsDBEventStoreTests.cs
+++ b/Source/EventFlow.EventStores.StreamsDb.Tests/IntegrationTests/StreamsDBEventStoreTests.cs
@@ -1,0 +1,63 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Threading.Tasks;
+using EventFlow.Configuration;
+using EventFlow.Extensions;
+using EventFlow.MetadataProviders;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Suites;
+using NUnit.Framework;
+using EventFlow.EventStores.StreamsDb.Extensions;
+
+namespace EventFlow.EventStores.StreamsDb.Tests.IntegrationTests
+{
+    [TestFixture]
+    [Timeout(30000)]
+    [Category(Categories.Integration)]
+    public class StreamsDBEventStoreTests : TestSuiteForEventStore
+    {
+        protected override IRootResolver CreateRootResolver(IEventFlowOptions eventFlowOptions)
+        {
+            var resolver = eventFlowOptions
+                .AddMetadataProvider<AddGuidMetadataProvider>()
+                .UseStreamsDbEventStore(Environment.GetEnvironmentVariable("SDB_HOST"))
+                .CreateResolver();
+
+            return resolver;
+        }
+
+        public override Task LoadAllEventsAsyncFindsEventsAfterLargeGaps()
+        {
+            // Need to reset DB in order to make this test work.
+
+            return Task.CompletedTask;
+        }
+
+        [Test]
+        public void TestFoo(){
+            
+        }
+    }
+}

--- a/Source/EventFlow.EventStores.StreamsDb.Tests/app.config
+++ b/Source/EventFlow.EventStores.StreamsDb.Tests/app.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.7.99.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
+++ b/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EventFlow" Version="0.74.3948" />
+    <PackageReference Include="StreamsDB.Driver" Version="0.9.3-dev.23" />
+  </ItemGroup>
+
+</Project>

--- a/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
+++ b/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StreamsDB.Driver" Version="0.9.3-dev.23" />
+    <PackageReference Include="StreamsDB.Driver" Version="0.9.4-dev.27" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
+++ b/Source/EventFlow.EventStores.StreamsDb/EventFlow.EventStores.StreamsDb.csproj
@@ -1,12 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <Title>EventFlow.EventStores.StreamsDb</Title>
+    <Authors>Rasmus Mikkelsen</Authors>
+    <Company>Rasmus Mikkelsen</Company>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Description>Event Store event store for EventFlow. Download it from https://geteventstore.com/</Description>
+    <PackageTags>CQRS ES event sourcing EventStore</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/eventflow/EventFlow</RepositoryUrl>
+    <PackageProjectUrl>https://docs.geteventflow.net/</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/eventflow/EventFlow/develop/icon-128.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EventFlow" Version="0.74.3948" />
     <PackageReference Include="StreamsDB.Driver" Version="0.9.3-dev.23" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventFlow\EventFlow.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/EventFlow.EventStores.StreamsDb/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/Extensions/EventFlowOptionsExtensions.cs
@@ -1,0 +1,27 @@
+﻿using EventFlow.Configuration;
+using EventFlow.Core;
+using EventFlow.Extensions;
+using StreamsDB.Driver;
+
+namespace EventFlow.EventStores.StreamsDb.Extensions
+{
+	public static class EventFlowOptionsExtensions
+	{
+		public static IEventFlowOptions UseStreamsDbEventStore(
+			this IEventFlowOptions eventFlowOptions,
+			string connectionString)
+		{
+			StreamsDBClient client = null;
+
+			using (var a = AsyncHelper.Wait)
+			{
+				a.Run(StreamsDBClient.Connect(connectionString), c => client = c);
+			}
+
+			return eventFlowOptions
+				.RegisterServices(f => f.Register(r => client, Lifetime.Singleton))
+				.UseEventStore<StreamsDbEventPersistence>();
+		}
+	}
+}
+

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -14,6 +14,8 @@ namespace EventFlow.EventStores.StreamsDb
 {
 	public class StreamsDbEventPersistence : IEventPersistence
 	{
+		private const int LIMIT = 1000;
+		
 		private readonly ILog _log;
 		private readonly StreamsDBClient _client;
 
@@ -105,7 +107,7 @@ namespace EventFlow.EventStores.StreamsDb
 
 			do
 			{
-                currentSlice = await _client.DB().ReadStreamForward(id.Value, fromEventSequenceNumber, int.MaxValue).ConfigureAwait(false);
+                currentSlice = await _client.DB().ReadStreamForward(id.Value, fromEventSequenceNumber, LIMIT).ConfigureAwait(false);
 				fromEventSequenceNumber = (int)currentSlice.Next;
 				streamEvents.AddRange(currentSlice.Messages);
 			}

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -18,6 +18,7 @@ namespace EventFlow.EventStores.StreamsDb
 		
 		private readonly ILog _log;
 		private readonly StreamsDBClient _client;
+		private readonly DB _db;
 
 		private class EventFlowEvent : ICommittedDomainEvent
 		{
@@ -31,6 +32,7 @@ namespace EventFlow.EventStores.StreamsDb
 		{
 			_log = log;
 			_client = client;
+			_db = _client.DB();
 		}
 
 		public async Task<AllCommittedEventsPage> LoadAllCommittedEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken)
@@ -89,7 +91,7 @@ namespace EventFlow.EventStores.StreamsDb
 
 			try
 			{
-				await _client.DB().AppendStream(id.Value, ConcurrencyCheck.ExpectStreamVersion(expectedVersion), streamsDbMessages).ConfigureAwait(false);
+				await _db.AppendStream(id.Value, ConcurrencyCheck.ExpectStreamVersion(expectedVersion), streamsDbMessages).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException e)
 			{

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -38,7 +38,7 @@ namespace EventFlow.EventStores.StreamsDb
 			IGlobalSlice currentSlice;
 			var from = globalPosition.IsStart
 				? StreamsDB.Driver.GlobalPosition.Begin
-				: StreamsDB.Driver.GlobalPosition.Begin.Parse(globalPosition.Value);
+				: StreamsDB.Driver.GlobalPosition.Parse(globalPosition.Value);
 
 			do
 			{

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -47,8 +47,9 @@ namespace EventFlow.EventStores.StreamsDb
 			do
 			{
 				currentSlice = await _client.DB().ReadGlobalForward(from, pageSize).ConfigureAwait(false);
+				
 				from = currentSlice.Next;
-				streamsDbMessages.AddRange(currentSlice.Messages);
+				streamsDbMessages.AddRange(currentSlice.Messages.Where(m => !m.Stream.StartsWith("#")));
 			}
 			while (streamsDbMessages.Count < pageSize && currentSlice.HasNext);
 

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+using EventFlow.Exceptions;
+using EventFlow.Logs;
+using StreamsDB.Driver;
+
+namespace EventFlow.EventStores.StreamsDb
+{
+	public class StreamsDbEventPersistence : IEventPersistence
+	{
+		private readonly ILog _log;
+		private readonly StreamsDBClient _client;
+
+		private class EventFlowEvent : ICommittedDomainEvent
+		{
+			public string AggregateId { get; set; }
+			public string Data { get; set; }
+			public string Metadata { get; set; }
+			public int AggregateSequenceNumber { get; set; }
+		}
+
+		public StreamsDbEventPersistence(ILog log, StreamsDBClient client)
+		{
+			_log = log;
+			_client = client;
+		}
+
+		public async Task<AllCommittedEventsPage> LoadAllCommittedEvents(GlobalPosition globalPosition, int pageSize, CancellationToken cancellationToken)
+		{
+			var streamsDbMessages = new List<Message>();
+
+			IGlobalSlice currentSlice;
+			var from = globalPosition.IsStart
+				? StreamsDB.Driver.GlobalPosition.Begin
+				: StreamsDB.Driver.GlobalPosition.Begin.Parse(globalPosition.Value);
+
+			do
+			{
+				currentSlice = await _client.DB().ReadGlobalForward(from, pageSize).ConfigureAwait(false);
+				from = currentSlice.Next;
+				streamsDbMessages.AddRange(currentSlice.Messages);
+			}
+			while (streamsDbMessages.Count < pageSize && currentSlice.HasNext);
+
+			var eventFlowEvents = Map(streamsDbMessages);
+
+			return new AllCommittedEventsPage(new GlobalPosition(currentSlice.Next.ToString()), eventFlowEvents);
+		}
+
+		public async Task<IReadOnlyCollection<ICommittedDomainEvent>> CommitEventsAsync(IIdentity id, IReadOnlyCollection<SerializedEvent> serializedEvents, CancellationToken cancellationToken)
+		{
+			var eventFlowEvents = serializedEvents
+				.Select(e => new EventFlowEvent
+				{
+					AggregateSequenceNumber = e.AggregateSequenceNumber,
+					Metadata = e.SerializedMetadata,
+					AggregateId = id.Value,
+					Data = e.SerializedData
+				})
+				.ToList();
+
+			var expectedVersion = serializedEvents.Min(e => e.AggregateSequenceNumber) - 1;
+
+			var streamsDbMessages = serializedEvents
+				.Select(e =>
+				{
+					var eventId = e.Metadata.EventId.Value;
+					var eventType = string.Format("{0}.{1}.{2}", e.Metadata[MetadataKeys.AggregateName], e.Metadata.EventName, e.Metadata.EventVersion);
+					var data = Encoding.UTF8.GetBytes(e.SerializedData);
+					var header = Encoding.UTF8.GetBytes(e.SerializedMetadata);
+
+					return new MessageInput
+					{
+						ID = eventId,
+						Type = eventType,
+						Header = header,
+						Value = data
+					};
+				})
+				.ToList();
+
+			try
+			{
+				await _client.DB().AppendStream(id.Value, ConcurrencyCheck.ExpectStreamVersion(expectedVersion), streamsDbMessages).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException e)
+			{
+				throw new OptimisticConcurrencyException(e.Message, e);
+			}
+
+			return eventFlowEvents;
+		}
+
+		public async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync(IIdentity id, int fromEventSequenceNumber, CancellationToken cancellationToken)
+		{
+			var streamEvents = new List<Message>();
+
+			IStreamSlice currentSlice;
+
+			do
+			{
+                currentSlice = await _client.DB().ReadStreamForward(id.Value, fromEventSequenceNumber, int.MaxValue).ConfigureAwait(false);
+				fromEventSequenceNumber = (int)currentSlice.Next;
+				streamEvents.AddRange(currentSlice.Messages);
+			}
+			while (currentSlice.HasNext);
+
+			return Map(streamEvents);
+		}
+
+		public Task DeleteEventsAsync(IIdentity id, CancellationToken cancellationToken)
+		{
+			throw new NotSupportedException();
+		}
+
+		private static IReadOnlyCollection<EventFlowEvent> Map(IEnumerable<Message> resolvedEvents)
+		{
+			return resolvedEvents
+				.Select(e => new EventFlowEvent
+				{
+					AggregateSequenceNumber = (int)e.Position,
+					Metadata = Encoding.UTF8.GetString(e.Header),
+					AggregateId = e.Stream,
+					Data = Encoding.UTF8.GetString(e.Value),
+				})
+				.ToList();
+		}
+	}
+}

--- a/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
+++ b/Source/EventFlow.EventStores.StreamsDb/StreamsDbEventPersistence.cs
@@ -94,7 +94,7 @@ namespace EventFlow.EventStores.StreamsDb
 			{
 				await _db.AppendStream(id.Value, ConcurrencyCheck.ExpectStreamVersion(expectedVersion), streamsDbMessages).ConfigureAwait(false);
 			}
-			catch (OperationCanceledException e)
+			catch (OperationAbortedException e)
 			{
 				throw new OptimisticConcurrencyException(e.Message, e);
 			}

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -24,6 +23,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
     <LangVersion>7.1</LangVersion>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/EventFlow.Tests/EventFlow.Tests.csproj
+++ b/Source/EventFlow.Tests/EventFlow.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using EventFlow.TestHelpers;
 using EventFlow.ValueObjects;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace EventFlow.Tests.UnitTests.ValueObjects
@@ -163,6 +164,52 @@ namespace EventFlow.Tests.UnitTests.ValueObjects
             // Assert
             (obj1 == obj2).Should().BeFalse();
             obj1.Equals(obj2).Should().BeFalse();
+        }
+
+        [JsonConverter(typeof(SingleValueObjectConverter))]
+        public class IntSingleValue : SingleValueObject<int>
+        {
+            public IntSingleValue(int value) : base(value) { }
+        }
+
+        public class WithNullableIntSingleValue
+        {
+            public IntSingleValue I { get; }
+
+            public WithNullableIntSingleValue(
+                IntSingleValue i)
+            {
+                I = i;
+            }
+        }
+
+        [Test]
+        public void NullableIntWithoutValue()
+        {
+            // Arrange
+            var json = JsonConvert.SerializeObject(new { });
+
+            // Act
+            var with = JsonConvert.DeserializeObject<WithNullableIntSingleValue>(json);
+
+            // Assert
+            with.Should().NotBeNull();
+            with.I.Should().BeNull();
+        }
+
+        [Test]
+        public void NullableIntWithValue()
+        {
+            // Arrange
+            var i = A<int>();
+            var json = JsonConvert.SerializeObject(new { i });
+
+            // Act
+            var with = JsonConvert.DeserializeObject<WithNullableIntSingleValue>(json);
+
+            // Assert
+            with.Should().NotBeNull();
+            with.I.Value.Should().Be(i);
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ValueObjects/SingleValueObjectTests.cs
@@ -166,6 +166,11 @@ namespace EventFlow.Tests.UnitTests.ValueObjects
             obj1.Equals(obj2).Should().BeFalse();
         }
 
+        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+            {
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            };
+
         [JsonConverter(typeof(SingleValueObjectConverter))]
         public class IntSingleValue : SingleValueObject<int>
         {
@@ -184,7 +189,7 @@ namespace EventFlow.Tests.UnitTests.ValueObjects
         }
 
         [Test]
-        public void NullableIntWithoutValue()
+        public void DeserializeNullableIntWithoutValue()
         {
             // Arrange
             var json = JsonConvert.SerializeObject(new { });
@@ -198,7 +203,7 @@ namespace EventFlow.Tests.UnitTests.ValueObjects
         }
 
         [Test]
-        public void NullableIntWithValue()
+        public void DeserializeNullableIntWithValue()
         {
             // Arrange
             var i = A<int>();
@@ -210,6 +215,32 @@ namespace EventFlow.Tests.UnitTests.ValueObjects
             // Assert
             with.Should().NotBeNull();
             with.I.Value.Should().Be(i);
+        }
+
+        [Test]
+        public void SerializeNullableIntWithoutValue()
+        {
+            // Arrange
+            var with = new WithNullableIntSingleValue(null);
+
+            // Act
+            var json = JsonConvert.SerializeObject(with, Settings);
+
+            // Assert
+            json.Should().Be("{}");
+        }
+
+        [Test]
+        public void SerializeNullableIntWithValue()
+        {
+            // Arrange
+            var with = new WithNullableIntSingleValue(new IntSingleValue(42));
+
+            // Act
+            var json = JsonConvert.SerializeObject(with, Settings);
+
+            // Assert
+            json.Should().Be("{\"I\":42}");
         }
     }
 }

--- a/Source/EventFlow/ValueObjects/SingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObject.cs
@@ -28,30 +28,6 @@ using EventFlow.Extensions;
 
 namespace EventFlow.ValueObjects
 {
-    public class NullableComparer<T> : IComparer<Nullable<T>>
-        where T : struct, IComparable<T>
-    {
-
-        public int Compare(Nullable<T> x, Nullable<T> y)
-        {
-            // Compare nulls acording MSDN specification
-
-            //Two nulls are equal
-            if (!x.HasValue && !y.HasValue)
-                return 0;
-
-            //Any object is greater than null
-            if (x.HasValue && !y.HasValue) 
-                return 1;
-
-            if (y.HasValue && !x.HasValue)
-                return -1;
-
-            //Otherwise compare the two values
-            return x.Value.CompareTo(y.Value);
-        }
-    }
-
     public abstract class SingleValueObject<T> : ValueObject, IComparable, ISingleValueObject
         where T : IComparable
     {

--- a/Source/EventFlow/ValueObjects/SingleValueObject.cs
+++ b/Source/EventFlow/ValueObjects/SingleValueObject.cs
@@ -28,6 +28,30 @@ using EventFlow.Extensions;
 
 namespace EventFlow.ValueObjects
 {
+    public class NullableComparer<T> : IComparer<Nullable<T>>
+        where T : struct, IComparable<T>
+    {
+
+        public int Compare(Nullable<T> x, Nullable<T> y)
+        {
+            // Compare nulls acording MSDN specification
+
+            //Two nulls are equal
+            if (!x.HasValue && !y.HasValue)
+                return 0;
+
+            //Any object is greater than null
+            if (x.HasValue && !y.HasValue) 
+                return 1;
+
+            if (y.HasValue && !x.HasValue)
+                return -1;
+
+            //Otherwise compare the two values
+            return x.Value.CompareTo(y.Value);
+        }
+    }
+
     public abstract class SingleValueObject<T> : ValueObject, IComparable, ISingleValueObject
         where T : IComparable
     {


### PR DESCRIPTION
**I've noticed you made the changes on the master branch, while EventFlow seems to favor develop as trunk branch.**

This pull request updates the develop branch to the the latest upstream and adds a StreamsDB event store test project.

All tests are green, accept the one for stream deletion. This is not yet supported by the current release of StreamsDB. But this will be included in the next beta release.

Here is the list of fixes included in this pull request as well:

* Configure netstandard2.0 to tests projects so the tests can be ran on Linux
* Upgrade StreamsDB driver package to 0.9.4-dev.27 and fix breaking changes
* Fix out of memory error because too large page size
* Minor improvement to resolve the DB only ones
* Fix deserialization error in global stream reading path by skip group streams
* Fix wrong concurrency exception expected